### PR TITLE
Peterk/db tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - influx_db
       - schema_registry
     ports:
-     - "8083:9102"
+     - "8083:8083"
     environment:
       CONNECT_BOOTSTRAP_SERVERS: 'kafka:29092'
       CONNECT_REST_ADVERTISED_HOST_NAME: kafka_connect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: confluentinc/cp-zookeeper:4.1.1
     hostname: zookeeper
     ports:
-      - "32181:32181"
+      - "32181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
@@ -18,7 +18,7 @@ services:
     depends_on:
       - zookeeper
     ports:
-    - "29092:29092"
+    - "29092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
@@ -58,7 +58,7 @@ services:
       - influx_db
       - schema_registry
     ports:
-     - "8083:8083"
+     - "8083:9102"
     environment:
       CONNECT_BOOTSTRAP_SERVERS: 'kafka:29092'
       CONNECT_REST_ADVERTISED_HOST_NAME: kafka_connect
@@ -91,4 +91,4 @@ services:
       CONNECTOR_CONNECT_INFLUX_DB: "doppler"
       CONNECTOR_CONNECT_INFLUX_USERNAME: root
       CONNECTOR_CONNECT_INFLUX_PASSWORD: "root"
-      CONNECTOR_CONNECT_INFLUX_KCQL: "INSERT INTO influxMeasure SELECT * FROM \"influx-topic\" WITHTIMESTAMP sys_time()"
+      CONNECTOR_CONNECT_INFLUX_KCQL: "INSERT INTO \"dopplerDataHistory\" SELECT \"lat\", \"lon\" FROM \"influx-topic\" WITHTIMESTAMP timeSinceEpoch WITHTAG(\"clientID\", \"eventID\")"

--- a/tests/influxDBAddData.sh
+++ b/tests/influxDBAddData.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-for i in {1..100}
+for i in {1..2}
 do
-    echo $i"\n"
+    echo $i
     j=$(($i%10))
     docker-compose exec influx_db \
-        curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary "server,host=$j,region=us-west value=0.64"
+        curl -i -XPOST 'http://influx_db:8086/write?db=doppler' -d "influxTest,name=server$j,region=us-west value=$j"
 done

--- a/tests/kafka_test.sh
+++ b/tests/kafka_test.sh
@@ -5,10 +5,6 @@ docker-compose exec kafka  \
 docker-compose exec kafka  \
   kafka-topics --describe --topic "influx-topic" --zookeeper zookeeper:32181
 docker-compose exec kafka  \
-  bash -c "echo '{\"name\": \"John Doe\"}' | kafka-console-producer --request-required-acks 1 --broker-list kafka:29092 --topic 'influx-topic'"
+  bash -c "echo '{\"clientID\":\"Bob\",\"eventID\":\"Sign In\",\"lat\":\"87687\",\"lon\":\"665.67676\",\"timeSinceEpoch\":419823796}' | kafka-console-producer --request-required-acks 1 --broker-list kafka:29092 --topic 'influx-topic'"
 docker-compose exec kafka  \
   kafka-console-consumer --bootstrap-server kafka:29092 --topic "influx-topic" --from-beginning --max-messages 1
-#echo "Kafka test completed, the InfluxDB manual test begins..."
-#docker-compose exec influx_db  \
- # influx
-#echo "InfluxDB test completed, the Kafka Connect test beings..."


### PR DESCRIPTION
Changed the exposed ports and updated the kcql query.
Run `docker-compose up -d`.
Wait about 5 seconds and then run `docker-compose ps`. Make sure all services say they are up.
Wait another couple of seconds and then then run `./tests/connectors_test.sh`. In active connectors you should see InfluxSink with the status running.
Next, run `./tests/kafka_test.sh`, and you should see a JSON object with clientID and several other properties after a couple of seconds.
Then, run `tests/connectors_test.sh` and make sure that InfluxSink has the status of running.
Lastly run `docker-compose exec influx_db influx`. Then type `USE doppler` and `SELECT * FROM dopplerDataHistory`. You should the same JSON data in the table.

Fixes #20 
It creates tags in the measurement for the clientID and eventID fields.