### PR TITLE
Peterk/error update

### DIFF
--- a/cmd/grpcTEST/serviceStart.go
+++ b/cmd/grpcTEST/serviceStart.go
@@ -18,8 +18,8 @@ func main() {
 	cbConn := os.Getenv("COUCHBASE_CONN")
 	//pass config variables so that they can be used later
 	err = service.Init(cbConn)
+	// if an error occurred in itialization, shutdown the server
 	if err != nil {
 		panic(err)
 	}
-
 }

--- a/cmd/testsend/testSend.go
+++ b/cmd/testsend/testSend.go
@@ -36,6 +36,7 @@ func main() {
 	//get true random
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
+		//time.Sleep(3 * time.Millisecond)
 		clientID := clientIDs[r.Int31n(int32(len(clientIDs)))]   //pick random client from clientIDs slice
 		eventID := eventIDs[r.Int31n(int32(len(eventIDs)))]      //pick random event from eventIDs slice
 		lat := (r.Float64() - .5) * 170                          //get random lat

--- a/internal/couchbase/couchbaseConn.go
+++ b/internal/couchbase/couchbaseConn.go
@@ -52,7 +52,7 @@ func (c *Couchbase) collectEvents(clientID string) error {
 		return err
 	}
 	// get the Events array into a slice
-	docFrag.Content("Events", &c.Doc.Events) // Error, but why is Doc.Events null?
+	docFrag.Content("Events", &c.Doc.Events)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (c *Couchbase) EventEnsure(clientID, eventID string) error {
 // Note: this resets the Doc data of the connector.
 func (c *Couchbase) CreateDocument(clientID, eventID string) error {
 	c.Doc.Events = append(c.Doc.Events, eventID)
-	_, err := c.Bucket.Upsert(fmt.Sprintf("doppler:client:%s", clientID), c.Doc.Events, 0)
+	_, err := c.Bucket.Upsert(fmt.Sprintf("%s:client:%s", c.bucketName, clientID), c.Doc.Events, 0)
 	c.Doc = &Doc{}
 	if err != nil {
 		return err
@@ -114,7 +114,6 @@ func (c *Couchbase) ConnectToCB(conn string) error {
 	spec := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	cluster, err := gocb.Connect(spec)
 	if err != nil {
-		fmt.Println("failed to connect")
 		return err
 	}
 	// authenticate the user and connect to the specified bucket


### PR DESCRIPTION
Updated what are error messages and what causes a panic. Error messages now have grpc status codes. Note: kafka being down does not currently constitute any kind of error or message to the user if the server is already running.
Fixes #68 
Test
`docker-compose up -d`
`go run cmd/grpcTEST/serviceStart.go`
` docker stop doppler-events_couchbase_1`
`go run cmd/testsend/testSend.go`
There should be an error with the message that couchbase is down.